### PR TITLE
Make value attr of PathValueOperation accessible

### DIFF
--- a/src/main/java/com/github/fge/jsonpatch/operation/PathValueOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/operation/PathValueOperation.java
@@ -82,4 +82,9 @@ public abstract class PathValueOperation extends JsonPatchOperationBase
     {
         return "op: " + getOp() + "; path: \"" + getPath() + "\"; value: " + value;
     }
+
+    public JsonNode getValue()
+    {
+        return value.deepCopy();
+    }
 }


### PR DESCRIPTION
In order to be able to check acceptance of `PathValueOperation` before applying it, you should be able to access the `value` that is passed to the operation.